### PR TITLE
Update iOSVideoPlayer.coffee

### DIFF
--- a/Components/iOSVideoPlayer.coffee
+++ b/Components/iOSVideoPlayer.coffee
@@ -823,6 +823,7 @@ class exports.iOSVideoPlayer extends VideoLayer
 			@animate
 				midX: point.x
 				midY: point.y
+				scale: 1
 				options: animOptions
 					
 			if event.offset.y > 100


### PR DESCRIPTION
Now video scales down to 1 when it is released after being swiped up in full-screen mode.